### PR TITLE
bring Rust AC program in line with C program (which speeds it up)

### DIFF
--- a/src/Rust/aho_corasick/src/main.rs
+++ b/src/Rust/aho_corasick/src/main.rs
@@ -126,6 +126,7 @@ fn enter_pattern(
 /*
   Build the goto function and the (partial) output function.
 */
+#[inline(never)]
 fn build_goto(
     patterns: &[String],
     goto_fn: &mut Vec<Vec<i32>>,
@@ -158,6 +159,7 @@ fn build_goto(
 /*
   Build the failure function and complete the output function.
 */
+#[inline(never)]
 fn build_failure(goto_fn: &[Vec<i32>], output_fn: &mut [Set]) -> Vec<usize> {
     // Need a queue of state numbers:
     let mut queue: VecDeque<usize> = VecDeque::new();
@@ -214,6 +216,7 @@ fn build_failure(goto_fn: &[Vec<i32>], output_fn: &mut [Set]) -> Vec<usize> {
     Instead of returning a single u32, this returns a Vec<u32> with size equal
     to `pattern_count`.
 */
+#[inline(never)]
 fn aho_corasick(
     sequence: &String,
     pattern_count: usize,

--- a/src/Rust/aho_corasick/src/main.rs
+++ b/src/Rust/aho_corasick/src/main.rs
@@ -9,7 +9,7 @@
 
 use common::setup::*;
 use std::cmp::Ordering;
-use std::collections::{HashSet, VecDeque};
+use std::collections::VecDeque;
 use std::env;
 use std::process::exit;
 use std::time::Instant;
@@ -29,6 +29,39 @@ const FAIL: i32 = -1;
     this array to shorten those loops.
 */
 const ALPHA_OFFSETS: &[usize] = &[65, 67, 71, 84];
+
+#[derive(Clone, Debug)]
+struct Set {
+    elements: Vec<usize>,
+}
+
+impl Set {
+    fn new() -> Set {
+        Set {
+            elements: Vec::with_capacity(8),
+        }
+    }
+
+    fn insert(&mut self, element: usize) {
+        self.elements.push(element);
+    }
+
+    fn contains(&self, element: usize) -> bool {
+        self.elements.contains(&element)
+    }
+
+    fn iter(&self) -> core::slice::Iter<'_, usize> {
+        self.elements.iter()
+    }
+
+    fn union(&mut self, other: &Set) {
+        for &element in other.elements.iter() {
+            if !self.contains(element) {
+                self.insert(element);
+            }
+        }
+    }
+}
 
 /*
    Simple function to create a new state for the goto_fn.
@@ -52,7 +85,7 @@ fn enter_pattern(
     pat: &[u8],
     idx: usize,
     goto_fn: &mut Vec<Vec<i32>>,
-    output_fn: &mut Vec<HashSet<usize>>,
+    output_fn: &mut Vec<Set>,
 ) {
     let len = pat.len();
     let mut j: usize = 0;
@@ -83,7 +116,7 @@ fn enter_pattern(
         // create the new state and append it to goto_fn. Also have to create
         // a new set object and add it to output_fn.
         goto_fn.push(create_new_state());
-        output_fn.push(HashSet::new());
+        output_fn.push(Set::new());
     }
 
     // Add the index of this pattern to the output_fn set for this state:
@@ -96,7 +129,7 @@ fn enter_pattern(
 fn build_goto(
     patterns: &[String],
     goto_fn: &mut Vec<Vec<i32>>,
-    output_fn: &mut Vec<HashSet<usize>>,
+    output_fn: &mut Vec<Set>,
 ) {
     // Convert the vector of strings into arrays of `u8`.
     let pats: Vec<&[u8]> = patterns.iter().map(|p| p.as_bytes()).collect();
@@ -107,7 +140,7 @@ fn build_goto(
 
     // Initialize state 0 for goto_fn and output_fn.
     goto_fn.push(create_new_state());
-    output_fn.push(HashSet::new());
+    output_fn.push(Set::new());
 
     // Add each pattern in turn:
     for (i, pattern) in pats.iter().enumerate() {
@@ -125,10 +158,7 @@ fn build_goto(
 /*
   Build the failure function and complete the output function.
 */
-fn build_failure(
-    goto_fn: &[Vec<i32>],
-    output_fn: &mut [HashSet<usize>],
-) -> Vec<usize> {
+fn build_failure(goto_fn: &[Vec<i32>], output_fn: &mut [Set]) -> Vec<usize> {
     // Need a queue of state numbers:
     let mut queue: VecDeque<usize> = VecDeque::new();
 
@@ -167,10 +197,8 @@ fn build_failure(
                     state = failure_fn[state];
                 }
                 failure_fn[ss] = goto_fn[state][*a] as usize;
-                output_fn[ss] = output_fn[ss]
-                    .union(&output_fn[failure_fn[ss]])
-                    .copied()
-                    .collect();
+                let failure_set = output_fn[failure_fn[ss]].clone();
+                output_fn[ss].union(&failure_set);
             }
         }
     }
@@ -191,7 +219,7 @@ fn aho_corasick(
     pattern_count: usize,
     goto_fn: &[Vec<i32>],
     failure_fn: &[usize],
-    output_fn: &[HashSet<usize>],
+    output_fn: &[Set],
 ) -> Vec<u32> {
     let sequence = sequence.as_bytes();
     let mut matches: Vec<u32> = vec![0; pattern_count];
@@ -255,7 +283,7 @@ pub fn run(argv: Vec<String>) -> i32 {
 
     // Initialize the multi-patterns structure.
     let mut goto_fn: Vec<Vec<i32>> = Vec::new();
-    let mut output_fn: Vec<HashSet<usize>> = Vec::new();
+    let mut output_fn: Vec<Set> = Vec::new();
     build_goto(&patterns_data, &mut goto_fn, &mut output_fn);
     let failure_fn = build_failure(&goto_fn, &mut output_fn);
 


### PR DESCRIPTION
After running `perf` on the Rust Aho-Corasick program, the problem was immediately obvious: there was a fair bit of time being spent in `HashSet`, which is a pretty heavy-weight data structure. Especially when compared to the `Set` data type used in the C version of AC.

This doesn't quite bring the Rust program in line with the C program on my machine, but it gets close:

```
$ make experiments
make -C C test-experiments SEQUENCES=../random-sequences.txt \
        PATTERNS=../random-patterns.txt ANSWERS=../random-answers.txt
make[1]: Entering directory '/home/andrew/clones/mscs-thesis-project/src/C'
---
language: c-gcc
algorithm: aho_corasick
runtime: 0.91546
---
language: c-llvm
algorithm: aho_corasick
runtime: 0.939958
make[1]: Leaving directory '/home/andrew/clones/mscs-thesis-project/src/C'
make -C Rust test-experiments SEQUENCES=../random-sequences.txt \
        PATTERNS=../random-patterns.txt ANSWERS=../random-answers.txt
make[1]: Entering directory '/home/andrew/clones/mscs-thesis-project/src/Rust'
---
language: rust
algorithm: aho_corasick
runtime: 1.06101315
make[1]: Leaving directory '/home/andrew/clones/mscs-thesis-project/src/Rust'
```

I did try a few other things, which ultimately led to a very small speed up combined:

* Used unchecked access in the main AC search loop. Since this is what the C program is doing. This does result in much tighter codegen, but no huge perf improvement.
* The AC C program uses `int` consistently everywhere, which is always a 32 bit signed integer. The Rust program however uses both `i32` and `usize` everywhere. While `i32` is the same as a C `int`, a `usize` is likely double in size, assuming you're on a 64-bit system. I tried moving _everything_ to `i32`---again, to match the C program---and this did change the codegen. But no huge perf improvement. Although I was getting some timings at `0.98s`, it wasn't consistent.

I took a profiler to the C llvm program as well, and the codegen there is tighter/different than the Rust program, even after doing all of the above. It therefore seems like the hot loop is prone to getting shuffled around. Probably there is a way to get the Rust program to emit the same codegen as the C program, but it's beyond my skill.